### PR TITLE
Changes to support dynamic fonts for iOS

### DIFF
--- a/android/.idea/misc.xml
+++ b/android/.idea/misc.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="zulu-11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')
     implementation project(':capacitor-status-bar')
+    implementation project(':capacitor-text-zoom')
     implementation project(':pantrist-capacitor-date-picker')
 
 }

--- a/android/app/src/main/assets/capacitor.plugins.json
+++ b/android/app/src/main/assets/capacitor.plugins.json
@@ -16,6 +16,10 @@
 		"classpath": "com.capacitorjs.plugins.statusbar.StatusBarPlugin"
 	},
 	{
+		"pkg": "@capacitor/text-zoom",
+		"classpath": "com.capacitorjs.plugins.textzoom.TextZoomPlugin"
+	},
+	{
 		"pkg": "@pantrist/capacitor-date-picker",
 		"classpath": "com.getcapacitor.community.datepicker.DatePickerPlugin"
 	}

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -14,5 +14,8 @@ project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor
 include ':capacitor-status-bar'
 project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')
 
+include ':capacitor-text-zoom'
+project(':capacitor-text-zoom').projectDir = new File('../node_modules/@capacitor/text-zoom/android')
+
 include ':pantrist-capacitor-date-picker'
 project(':pantrist-capacitor-date-picker').projectDir = new File('../node_modules/@pantrist/capacitor-date-picker/android')

--- a/angular.json
+++ b/angular.json
@@ -160,7 +160,8 @@
   "cli": {
     "schematicCollections": [
       "@ionic/angular-toolkit"
-    ]
+    ],
+    "analytics": false
   },
   "schematics": {
     "@ionic/angular-toolkit:component": {

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -15,6 +15,7 @@ def capacitor_pods
   pod 'CapacitorHaptics', :path => '../../node_modules/@capacitor/haptics'
   pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'
   pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
+  pod 'CapacitorTextZoom', :path => '../../node_modules/@capacitor/text-zoom'
   pod 'PantristCapacitorDatePicker', :path => '../../node_modules/@pantrist/capacitor-date-picker'
 end
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@capacitor/ios": "4.6.1",
         "@capacitor/keyboard": "^4.1.0",
         "@capacitor/status-bar": "4.1.1",
+        "@capacitor/text-zoom": "^4.1.0",
         "@ionic/angular": "6.4.1",
         "@ngrx/effects": "^16.1.0",
         "@ngrx/store": "^16.1.0",
@@ -2761,6 +2762,14 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-4.1.1.tgz",
       "integrity": "sha512-3wosxMD1XuIFz88+c2GdVEHSJV6u7suOeKQjyWf3zf9eFr622Sg+udZqDbC0dtTWXw97BWyCjv3r1EYJw7XnIA==",
+      "peerDependencies": {
+        "@capacitor/core": "^4.0.0"
+      }
+    },
+    "node_modules/@capacitor/text-zoom": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/text-zoom/-/text-zoom-4.1.0.tgz",
+      "integrity": "sha512-eFKG3psotvvZz+A1XeGG+4vjJ0Q3Y3iMaxV9fhueYj4APLGP1enVI1b2EvCMg6tPDeX1WHtRMp/8k9phQkDDFw==",
       "peerDependencies": {
         "@capacitor/core": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@capacitor/ios": "4.6.1",
     "@capacitor/keyboard": "^4.1.0",
     "@capacitor/status-bar": "4.1.1",
+    "@capacitor/text-zoom": "^4.1.0",
     "@ionic/angular": "6.4.1",
     "@ngrx/effects": "^16.1.0",
     "@ngrx/store": "^16.1.0",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,8 @@ import {Component, OnInit} from '@angular/core';
 import {AssessmentService} from './services/assessments/assessment.service';
 import {ModalController, Platform} from '@ionic/angular';
 import {EditProfilePage} from './pages/edit-profile/edit-profile.page';
+import { TextZoom } from '@capacitor/text-zoom';
+import { App } from '@capacitor/app';
 
 // import { GoogleSigninService } from './google-signin.service';
 
@@ -21,7 +23,11 @@ export class AppComponent implements OnInit {
     private modalCtrl: ModalController,
     public platform: Platform
   ) {
-    console.log('assessmentService.load()');
+    App.addListener('appStateChange', ({ isActive }) => {
+      TextZoom.getPreferred().then(value => {
+        TextZoom.set(value);
+      })
+    });
     assessmentService.load();
     this.initializeApp();
   }


### PR DESCRIPTION
This fixes text scaling for iOS (and Android keeps working as is after the change). Image scaling is still not working but I think we can tackle that as a separate PR (under the same GitHub issue).